### PR TITLE
Fix/bump deps

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -31,7 +31,7 @@ function build (from, to, options) {
 
   if (!options.skipReveal) {
     notify("options", "--skip-reveal", "to not copy the following reveal files");
-    REVEAL_FILES.forEach(([src, filter]) => copy(src, to, { filter: x => filter && filter.test(x) }));
+    REVEAL_FILES.forEach(([src, filter]) => copy(src, to, { filter }));
     copy(HL_STYLES, path.join(to, "css", "highlight"));
   }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -31,7 +31,7 @@ function build (from, to, options) {
 
   if (!options.skipReveal) {
     notify("options", "--skip-reveal", "to not copy the following reveal files");
-    REVEAL_FILES.forEach(([src, filter]) => copy(src, to, { filter }));
+    REVEAL_FILES.forEach(([src, filter]) => copy(src, to, { filter: x => filter && filter.test(x) }));
     copy(HL_STYLES, path.join(to, "css", "highlight"));
   }
 

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("path");
+const { last } = require("lodash/fp");
 
 const REVEAL = getModuleRoot("reveal.js");
 const DATA = path.resolve(__dirname, "..", "data");
@@ -8,12 +9,12 @@ const DATA = path.resolve(__dirname, "..", "data");
 // 3rd party
 // these reveal and highlight files will be copied to target unless --skip-reveal is true
 
-// in these tuples, first is dir, second is optional whitelist regexp
+// in these tuples, first is source dir/file, second is a function to filter in when true
 exports.REVEAL_FILES = [
-  ["css", /\.css$/], // remove extraneous sass files
-  ["js"],
-  ["lib", /league|source|head/], // keep only relevant fonts and js
-  ["plugin"]
+  ["css", src => !src.endsWith("scss")], // remove extraneous sass files
+  ["js", () => true],
+  ["lib", src => /js|css|lib|league|source|head/.test(last(src.split("/")))], // keep only relevant fonts and js
+  ["plugin", () => true]
 ].map(([dir, regexp]) => [path.join(REVEAL, dir), regexp]);
 
 exports.PRINT_PDF_JS = path.resolve(REVEAL, "plugin", "print-pdf", "print-pdf.js");

--- a/package.json
+++ b/package.json
@@ -7,24 +7,24 @@
     "prez": "bin/prez.js"
   },
   "dependencies": {
-    "colors": "^1.0.3",
-    "connect": "^3.6.5",
+    "colors": "^1.3.1",
+    "connect": "^3.6.6",
     "connect-livereload": "^0.6.0",
     "diacritics": "^1.3.0",
-    "escape-html": "^1.0.1",
-    "fs-extra": "^0.30.0",
+    "escape-html": "^1.0.3",
+    "fs-extra": "^7.0.0",
     "highlight.js": "^9.12.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "minimatch": "^3.0.4",
-    "node-watch": "^0.5.5",
-    "opn": "^5.1.0",
+    "node-watch": "^0.5.8",
+    "opn": "^5.3.0",
     "optimist": "^0.6.1",
-    "rc": "^1.2.1",
-    "reveal.js": "^3.5.0",
+    "rc": "^1.2.8",
+    "reveal.js": "^3.6.0",
     "serve-index": "^1.9.1",
-    "serve-static": "^1.13.1",
-    "tiny-lr": "^1.0.5",
-    "update-notifier": "^2.3.0"
+    "serve-static": "^1.13.2",
+    "tiny-lr": "^1.1.1",
+    "update-notifier": "^2.5.0"
   },
   "scripts": {
     "lint": "eslint lib bin",
@@ -41,11 +41,11 @@
   },
   "homepage": "https://github.com/byteclubfr/prez",
   "devDependencies": {
-    "ava": "^0.22.0",
-    "eslint": "^4.8.0",
+    "ava": "^0.25.0",
+    "eslint": "^5.2.0",
     "eslint-plugin-lodash-fp": "^2.1.3"
   },
   "optionalDependencies": {
-    "marked": "^0.3.5"
+    "marked": "^0.4.0"
   }
 }


### PR DESCRIPTION
- Bump all dependencies to latest
- Fix an issue with fs-extra related to a breaking change. `filter` passed to `copySync` must now be a function, see https://github.com/jprichardson/node-fs-extra/blob/master/docs/copy-sync.md. Function is applied to directories as well as files, so needed changes to the regexes

- Tests pass
- prez --init works
- prez --serve works, presentation CSS and JS looks fine